### PR TITLE
Fix URLs and add ARM64 version

### DIFF
--- a/tree-tagger.rb
+++ b/tree-tagger.rb
@@ -1,97 +1,104 @@
-require "formula"
-
 class TreeTagger < Formula
-
+  desc "Part-of-speech tagger for many languages"
   homepage "http://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/"
-  url "http://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/tree-tagger-MacOSX-3.2.tar.gz"
-  sha256 "d7551c50fa8ad99c9df48a9e6ebec10998b16cfee141d35ebab1d019dae9101d"
-  version "3.2"
+  if Hardware::CPU.arm?
+    url "https://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/tree-tagger-ARM64-3.2.tar.gz"
+    sha256 "b70d1d4cd625b6cbc9768b08c2e38ea35d158bc42954d062656adc76c647d67a"
+  else
+    url "https://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/tree-tagger-MacOSX-3.2.3.tar.gz"
+    sha256 "bb8585b8c96cce5132cf69c576fde20f69632da881b12b1926bb4534edef9ce7"
+  end
 
-  option "without-english"         , "Do not install English parameter files."
-  option "with-bulgarian"          , "Install Bulgarian parameter files."
-  option "with-dutch"              , "Install Dutch parameter files."
-  option "with-estonian"           , "Install Estonian parameter files."
-  option "with-finnish"            , "Install Finnish parameter files."
-  option "with-french"             , "Install French parameter files."
-  option "with-galician"           , "Install Galician parameter files."
-  option "with-german"             , "Install German parameter files."
-  option "with-italian"            , "Install Italian parameter files."
-  option "with-latin"              , "Install Latin parameter files."
-  option "with-mongolian"          , "Install Mongolian parameter files."
-  option "with-polish"             , "Install Polish parameter files."
-  option "with-russian"            , "Install Russian parameter files."
-  option "with-slovak"             , "Install Slovak parameter files."
-  option "with-spanish"            , "Install Spanish parameter files."
-  option "with-swahili"            , "Install Swahili parameter files."
+  option "without-english", "Do not install English parameter files."
+  option "with-bulgarian", "Install Bulgarian parameter files."
+  option "with-dutch", "Install Dutch parameter files."
+  option "with-estonian", "Install Estonian parameter files."
+  option "with-finnish", "Install Finnish parameter files."
+  option "with-french", "Install French parameter files."
+  option "with-french-spoken", "Install Spoken French parameter files."
+  option "with-galician", "Install Galician parameter files."
+  option "with-german", "Install German parameter files."
+  option "with-italian", "Install Italian parameter files."
+  option "with-latin", "Install Latin parameter files."
+  option "with-mongolian", "Install Mongolian parameter files."
+  option "with-polish", "Install Polish parameter files."
+  option "with-portuguese", "Install Portuguese parameter files."
+  option "with-russian", "Install Russian parameter files."
+  option "with-slovak", "Install Slovak parameter files."
+  option "with-spanish", "Install Spanish parameter files."
+  option "with-swahili", "Install Swahili parameter files."
 
-  option "without-english-chunker" , "Do not install English chunker parameter files."
-  option "with-french-chunker"     , "Install French chunker parameter files."
-  option "with-german-chunker"     , "Install German chunker parameter files."
-
+  option "without-english-chunker", "Do not install English chunker parameter files."
+  option "with-french-chunker", "Install French chunker parameter files."
+  option "with-german-chunker", "Install German chunker parameter files."
 
   depends_on "wget" => :build
-
 
   def install
     system "wget", "http://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/tagger-scripts.tar.gz"
 
     unless build.without? "english"
-      system "wget", "http://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/english-par-linux-3.2-utf8.bin.gz"
+      system "wget", "https://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/english.par.gz"
     end
     if build.with? "bulgarian"
-      system "wget", "http://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/bulgarian-par-linux-3.2-utf8.bin.gz"
+      system "wget", "https://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/bulgarian.par.gz"
     end
-    if build.with? "dutch"
-      system "wget", "http://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/dutch-par-linux-3.2-utf8.bin.gz"
-    end
+    system "wget", "https://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/dutch.par.gz" if build.with? "dutch"
     if build.with? "estonian"
-      system "wget", "http://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/estonian-par-linux-3.2-utf8.bin.gz"
+      system "wget", "https://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/estonian.par.gz"
     end
     if build.with? "finnish"
-      system "wget", "http://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/finnish-par-linux-3.2-utf8.bin.gz"
+      system "wget", "https://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/finnish.par.gz"
     end
     if build.with? "french"
-      system "wget", "http://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/french-par-linux-3.2-utf8.bin.gz"
+      system "wget", "https://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/french.par.gz"
+    end
+    if build.with? "french-spoken"
+      system "wget", "https://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/french-spoken.par.gz"
     end
     if build.with? "galician"
-      system "wget", "http://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/galician-par-linux-3.2.bin.gz"
+      system "wget", "https://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/galician.par.gz"
     end
     if build.with? "german"
-      system "wget", "http://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/german-par-linux-3.2-utf8.bin.gz"
+      system "wget", "https://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/german.par.gz"
     end
     if build.with? "italian"
-      system "wget", "http://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/italian-par-linux-3.2-utf8.bin.gz"
+      system "wget", "https://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/italian.par.gz"
     end
-    if build.with? "latin"
-      system "wget", "http://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/latin-par-linux-3.2.bin.gz"
-    end
+    system "wget", "https://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/latin.par.gz" if build.with? "latin"
     if build.with? "mongolian"
-      system "wget", "http://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/mongolian-par-linux-3.2.bin.gz"
+      system "wget", "https://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/mongolian.par.gz"
     end
     if build.with? "polish"
-      system "wget", "http://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/polish-par-linux-3.2-utf8.bin.gz"
+      system "wget", "https://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/polish.par.gz"
+    end
+    if build.with? "portuguese"
+      system "wget", "https://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/portuguese.par.gz"
     end
     if build.with? "russian"
-      system "wget", "http://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/russian-par-linux-3.2-utf8.bin.gz"
+      system "wget", "https://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/russian.par.gz"
     end
     if build.with? "slovak"
-      system "wget", "http://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/slovak-par-linux-3.2-utf8.bin.gz"
+      system "wget", "https://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/slovak.par.gz"
     end
     if build.with? "spanish"
-      system "wget", "http://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/spanish-par-linux-3.2-utf8.bin.gz"
+      system "wget", "https://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/spanish.par.gz"
     end
     if build.with? "swahili"
-      system "wget", "http://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/swahili-par-linux-3.2.bin.gz"
+      system "wget", "https://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/swahili.par.gz"
     end
 
     unless build.without? "english-chunker"
-      system "wget", "http://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/english-chunker-par-linux-3.2-utf8.bin.gz"
+      system "wget", "https://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/english-chunker.par.gz"
     end
     if build.with? "french-chunker"
-      system "wget", "http://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/french-chunker-par-linux-3.2-utf8.bin.gz"
+      system "wget", "https://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/french-chunker.par.gz"
     end
     if build.with? "german-chunker"
-      system "wget", "http://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/german-chunker-par-linux-3.2-utf8.bin.gz"
+      system "wget", "https://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/german-chunker.par.gz"
+    end
+    if build.with? "spanish-chunker"
+      system "wget", "https://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/spanish-chunker.par.gz"
     end
 
     system "wget", "http://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/install-tagger.sh"
@@ -99,16 +106,14 @@ class TreeTagger < Formula
     system "./install-tagger.sh"
 
     Dir["cmd/*"].each do |cmd_file|
-      begin
-        inreplace cmd_file do |cmd_text|
-          cmd_text.gsub!(/BIN=.*/, "BIN=#{libexec}/bin")
-          cmd_text.gsub!(/CMD=.*/, "CMD=#{libexec}/cmd")
-          cmd_text.gsub!(/LIB=.*/, "LIB=#{libexec}/lib")
-        end
-        rescue
-          #uncoment to enable verbose mode:
-          #puts "Warning: lines to replace not found in #{cmd_file}"
+      inreplace cmd_file do |cmd_text|
+        cmd_text.gsub!(/BIN=.*/, "BIN=#{libexec}/bin")
+        cmd_text.gsub!(/CMD=.*/, "CMD=#{libexec}/cmd")
+        cmd_text.gsub!(/LIB=.*/, "LIB=#{libexec}/lib")
       end
+      rescue
+      # uncoment to enable verbose mode:
+      # puts "Warning: lines to replace not found in #{cmd_file}"
     end
 
     rm "install-tagger.sh"
@@ -118,15 +123,14 @@ class TreeTagger < Formula
     bin.install_symlink Dir["#{libexec}/cmd/*"]
   end
 
-
-  def caveats; <<~EOS
-    You may want to add to your path
-      #{libexec}/bin
-    and
-      #{libexec}/cmd.
-  EOS
+  def caveats
+    <<~EOS
+      You may want to add to your path
+        #{libexec}/bin
+      and
+        #{libexec}/cmd.
+    EOS
   end
-
 
   test do
     system "false"


### PR DESCRIPTION
- Fixed all language parameters URLS (now unversioned URLs)
- Update to v3.2.3
- Add ARM64 version v3.2 for M1 Macs
- Added language parameters: Spoken French, Portuguese (there are still more that are missing here)
- Fixed some styling recommendations from Homebrew via `brew style --fix`
- Added a description (`desc`)